### PR TITLE
Remove debug console.log

### DIFF
--- a/src/immerser.js
+++ b/src/immerser.js
@@ -140,7 +140,6 @@ export default class Immerser {
   validateSolidClassnameArray() {
     const layerCount = this.layerNodeArray.length;
     const classnamesCount = this.options.solidClassnameArray.length;
-    console.log(layerCount, classnamesCount);
     if (classnamesCount !== layerCount) {
       showError({
         message: 'solidClassnameArray length differs from count of layers',


### PR DESCRIPTION
Hi,

I've noticed there is still a `console.log` that will be visible on sites in production. I think it's cleaner to remove it.
By the way, thank you for this nice library, it was very useful to me!

Robin.